### PR TITLE
feat : Removed email-password login from backend, fixed docs

### DIFF
--- a/backend/api-gateway/QUICKSTART.md
+++ b/backend/api-gateway/QUICKSTART.md
@@ -17,46 +17,21 @@ Server will be available at:
 
 ## 🧪 Test the API
 
-### 1. Login with Demo User
+### 1. Start OAuth Login
+
+Use one of the OAuth entry points:
 
 ```bash
-curl -X POST http://localhost:14000/api/v1/auth/login \
-  -H "Content-Type: application/json" \
-  -d '{
-    "email": "demo@eloinsight.dev",
-    "password": "password123"
-  }'
+xdg-open http://localhost:14000/api/v1/auth/lichess/login
 ```
 
-**Response**:
-```json
-{
-  "user": {
-    "id": "1",
-    "email": "demo@eloinsight.dev",
-    "username": "demo"
-  },
-  "tokens": {
-    "accessToken": "eyJhbGci...",
-    "refreshToken": "eyJhbGci...",
-    "expiresIn": 900
-  }
-}
-```
-
-### 2. Register New User
+or
 
 ```bash
-curl -X POST http://localhost:14000/api/v1/auth/register \
-  -H "Content-Type: application/json" \
-  -d '{
-    "email": "newuser@example.com",
-    "username": "newuser",
-    "password": "password123"
-  }'
+xdg-open http://localhost:14000/api/v1/auth/google/login
 ```
 
-### 3. Access Protected Endpoint
+### 2. Access Protected Endpoint
 
 ```bash
 # Save the access token from login response
@@ -66,21 +41,21 @@ curl -X GET http://localhost:14000/api/v1/users/me \
   -H "Authorization: Bearer $TOKEN"
 ```
 
-### 4. Get User Statistics
+### 3. Get User Statistics
 
 ```bash
 curl -X GET http://localhost:14000/api/v1/users/stats \
   -H "Authorization: Bearer $TOKEN"
 ```
 
-### 5. Get Games List
+### 4. Get Games List
 
 ```bash
 curl -X GET "http://localhost:14000/api/v1/games?page=1&limit=20" \
   -H "Authorization: Bearer $TOKEN"
 ```
 
-### 6. Request Game Analysis
+### 5. Request Game Analysis
 
 ```bash
 curl -X POST http://localhost:14000/api/v1/analysis/game-123 \
@@ -107,10 +82,10 @@ You can:
 
 ## 🔐 Authentication Flow
 
-1. **Login** → Get access token
-2. **Use token** in `Authorization: Bearer <token>` header
-3. **Token expires** after 15 minutes
-4. **Refresh** using refresh token (valid for 7 days)
+1. **OAuth login** via Lichess or Google
+2. **Frontend receives** access and refresh tokens from the callback flow
+3. **Use token** in `Authorization: Bearer <token>` header
+4. **Refresh** using refresh token when needed
 
 ## 📁 Project Structure
 

--- a/backend/api-gateway/README.md
+++ b/backend/api-gateway/README.md
@@ -26,8 +26,8 @@ npm run build && npm run start:prod
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| `POST` | `/auth/register` | User registration |
-| `POST` | `/auth/login` | User login |
+| `GET` | `/auth/lichess/login` | Start Lichess OAuth login |
+| `GET` | `/auth/google/login` | Start Google OAuth login |
 | `POST` | `/auth/refresh` | Refresh tokens |
 | `GET` | `/users/me` | Get current user |
 | `GET` | `/games` | List user games |

--- a/backend/api-gateway/src/auth/auth.controller.ts
+++ b/backend/api-gateway/src/auth/auth.controller.ts
@@ -2,12 +2,9 @@ import { Controller, Post, Body, HttpCode, HttpStatus, Get, Query, UseGuards, Re
 import { ApiTags, ApiOperation, ApiResponse, ApiQuery, ApiBearerAuth } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
 import {
-    LoginDto,
-    RegisterDto,
     VerifyEmailDto,
     ResendVerificationDto,
     AuthResponseDto,
-    RegisterResponseDto,
     VerifyResponseDto,
 } from './dto/auth.dto';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
@@ -21,18 +18,6 @@ export class AuthController {
         private authService: AuthService,
         private configService: ConfigService,
     ) { }
-
-    @Post('register')
-    @ApiOperation({ summary: 'Register a new user' })
-    @ApiResponse({
-        status: 201,
-        description: 'User registered. Verification email sent.',
-        type: RegisterResponseDto,
-    })
-    @ApiResponse({ status: 400, description: 'Email/username already exists or validation failed' })
-    async register(@Body() registerDto: RegisterDto): Promise<RegisterResponseDto> {
-        return this.authService.register(registerDto);
-    }
 
     @Get('verify-email')
     @ApiOperation({ summary: 'Verify email address' })
@@ -69,19 +54,6 @@ export class AuthController {
     })
     async resendVerification(@Body() resendDto: ResendVerificationDto) {
         return this.authService.resendVerification(resendDto.email);
-    }
-
-    @Post('login')
-    @HttpCode(HttpStatus.OK)
-    @ApiOperation({ summary: 'Login with email and password' })
-    @ApiResponse({
-        status: 200,
-        description: 'Successfully logged in',
-        type: AuthResponseDto,
-    })
-    @ApiResponse({ status: 401, description: 'Invalid credentials or email not verified' })
-    async login(@Body() loginDto: LoginDto): Promise<AuthResponseDto> {
-        return this.authService.login(loginDto);
     }
 
     @Post('refresh')

--- a/backend/api-gateway/src/auth/auth.service.ts
+++ b/backend/api-gateway/src/auth/auth.service.ts
@@ -1,9 +1,8 @@
 import { Injectable, UnauthorizedException, BadRequestException, OnModuleInit, Logger } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
-import * as bcrypt from 'bcrypt';
 import { v4 as uuidv4 } from 'uuid';
-import { LoginDto, RegisterDto, VerifyResponseDto } from './dto/auth.dto';
+import { VerifyResponseDto } from './dto/auth.dto';
 import { EmailService } from './email.service';
 import { PrismaService } from '../prisma/prisma.service';
 import * as crypto from 'crypto';
@@ -27,66 +26,6 @@ export class AuthService {
         private prisma: PrismaService,
     ) { }
 
-    async register(registerDto: RegisterDto) {
-        const { email, username, password } = registerDto;
-
-        // Check if email already exists
-        const existingEmail = await this.prisma.user.findUnique({ where: { email } });
-        if (existingEmail) {
-            throw new BadRequestException('Email already registered');
-        }
-
-        // Check if username already exists
-        const existingUsername = await this.prisma.user.findUnique({ where: { username } });
-        if (existingUsername) {
-            throw new BadRequestException('Username already taken');
-        }
-
-        // Hash password
-        const hashedPassword = await bcrypt.hash(password, 10);
-
-        // Create user
-        // Note: Prisma schema uses 'passwordHash', 'emailVerified', 'isActive'
-        const user = await this.prisma.user.create({
-            data: {
-                email,
-                username,
-                passwordHash: hashedPassword,
-                emailVerified: false,
-                // Default isActive is true in schema
-            },
-        });
-
-        // Normally we'd send a verification email here.
-        // For now, we'll keep the logic simple or just log it.
-        // If you have a verification table or column, logic goes here.
-
-        // Let's assume we want to auto-verify for dev convenience or implement proper flow
-        // The original code had verification logic with tokens. 
-        // Integrating that requires schema support for verification tokens if not present.
-
-        // Since the current schema doesn't explicitly show verificationToken columns in the snippet I saw earlier,
-        // (Only emailVerified boolean), I'll skip token storage unless I add it to schema.
-        // However, I'll log that verification is skipped/mocked for now to unblock login.
-
-        /* 
-           If verification is strictly required:
-           We need to store the token somewhere (Redis, separate table, or add column to User).
-           For this refactor, I will auto-verify or let the user login immediately if allowed, 
-           or leave emailVerified=false and require manual update like we did before.
-        */
-
-        return {
-            message: 'Registration successful. You can now log in.',
-            user: {
-                id: user.id,
-                email: user.email,
-                username: user.username,
-                isVerified: user.emailVerified,
-            },
-        };
-    }
-
     async verifyEmail(token: string): Promise<VerifyResponseDto> {
         // Without a token column in DB, we can't implement this exactly same way yet.
         // Would need to add `verificationToken` to User model in schema.
@@ -97,37 +36,6 @@ export class AuthService {
         return {
             message: 'Verification feature pending schema update.',
         };
-    }
-
-    async login(loginDto: LoginDto) {
-        const { email, password } = loginDto;
-
-        // Find user
-        const user = await this.prisma.user.findUnique({
-            where: { email },
-            include: {
-                profile: true,
-                linkedAccounts: true, // to load chess usernames if needed
-            }
-        });
-
-        if (!user) {
-            throw new UnauthorizedException('Invalid credentials');
-        }
-
-        // Verify password
-        const isPasswordValid = await bcrypt.compare(password, user.passwordHash);
-        if (!isPasswordValid) {
-            throw new UnauthorizedException('Invalid credentials');
-        }
-
-        // Check if verified
-        if (!user.emailVerified) {
-            throw new UnauthorizedException('Please verify your email before logging in');
-        }
-
-        // Generate tokens
-        return this.generateTokens(user);
     }
 
     async refreshToken(refreshToken: string) {

--- a/backend/api-gateway/src/auth/dto/auth.dto.ts
+++ b/backend/api-gateway/src/auth/dto/auth.dto.ts
@@ -1,61 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEmail, IsNotEmpty, IsString, MinLength, Matches } from 'class-validator';
-
-export class LoginDto {
-    @ApiProperty({
-        example: 'user@example.com',
-        description: 'User email address',
-    })
-    @IsEmail()
-    @IsNotEmpty()
-    email: string;
-
-    @ApiProperty({
-        example: 'password123',
-        description: 'User password',
-        minLength: 6,
-    })
-    @IsString()
-    @IsNotEmpty()
-    @MinLength(6)
-    password: string;
-}
-
-export class RegisterDto {
-    @ApiProperty({
-        example: 'user@example.com',
-        description: 'User email address',
-    })
-    @IsEmail()
-    @IsNotEmpty()
-    email: string;
-
-    @ApiProperty({
-        example: 'johndoe',
-        description: 'Username (alphanumeric, 3-20 characters)',
-        minLength: 3,
-    })
-    @IsString()
-    @IsNotEmpty()
-    @MinLength(3)
-    @Matches(/^[a-zA-Z0-9_]+$/, {
-        message: 'Username can only contain letters, numbers, and underscores',
-    })
-    username: string;
-
-    @ApiProperty({
-        example: 'Password123!',
-        description: 'User password (min 8 chars, 1 uppercase, 1 lowercase, 1 number)',
-        minLength: 8,
-    })
-    @IsString()
-    @IsNotEmpty()
-    @MinLength(8)
-    @Matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/, {
-        message: 'Password must contain at least 1 uppercase, 1 lowercase, and 1 number',
-    })
-    password: string;
-}
+import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
 
 export class VerifyEmailDto {
     @ApiProperty({
@@ -91,19 +35,6 @@ export class AuthResponseDto {
         accessToken: string;
         refreshToken: string;
         expiresIn: number;
-    };
-}
-
-export class RegisterResponseDto {
-    @ApiProperty()
-    message: string;
-
-    @ApiProperty()
-    user: {
-        id: string;
-        email: string;
-        username: string;
-        isVerified: boolean;
     };
 }
 

--- a/backend/database/prisma/seed.ts
+++ b/backend/database/prisma/seed.ts
@@ -662,9 +662,8 @@ async function main() {
     console.log('   • Opening Statistics: 3');
     console.log('   • Sync Jobs: 2');
     console.log('   • Analysis Jobs: 3');
-    console.log('\n🔑 Demo Credentials:');
-    console.log('   Email: demo@eloinsight.com');
-    console.log('   Password: password123');
+    console.log('\n🔑 Demo Access:');
+    console.log('   Use the seeded linked accounts with the OAuth flows exposed by the frontend.');
 }
 
 main()

--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -20,65 +20,15 @@ EloInsight provides a RESTful API for frontend-backend communication. All endpoi
 
 ## Authentication
 
-### Register
-Create a new user account.
+### OAuth Login
+Authenticate via the supported OAuth providers.
 
 ```http
-POST /api/v1/auth/register
-Content-Type: application/json
-
-{
-  "email": "player@example.com",
-  "username": "chessmaster",
-  "password": "SecurePass123!"
-}
+GET /api/v1/auth/lichess/login
+GET /api/v1/auth/google/login
 ```
 
-**Response** (201 Created):
-```json
-{
-  "user": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "email": "player@example.com",
-    "username": "chessmaster",
-    "createdAt": "2026-01-11T10:30:00Z"
-  },
-  "tokens": {
-    "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
-    "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
-    "expiresIn": 900
-  }
-}
-```
-
-### Login
-Authenticate existing user.
-
-```http
-POST /api/v1/auth/login
-Content-Type: application/json
-
-{
-  "email": "player@example.com",
-  "password": "SecurePass123!"
-}
-```
-
-**Response** (200 OK):
-```json
-{
-  "user": {
-    "id": "550e8400-e29b-41d4-a716-446655440000",
-    "email": "player@example.com",
-    "username": "chessmaster"
-  },
-  "tokens": {
-    "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
-    "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
-    "expiresIn": 900
-  }
-}
-```
+These endpoints redirect the user to the provider OAuth flow. On success, the frontend receives access and refresh tokens through the callback redirect.
 
 ### Refresh Token
 Get new access token using refresh token.

--- a/docs/local-setup.md
+++ b/docs/local-setup.md
@@ -317,35 +317,8 @@ echo "API: http://localhost:14000/api/v1"
 2. Click "Continue with Lichess" (recommended)
 3. Or sign up with email
 
-### Option 2: Create via script
-```bash
-cd backend/api-gateway
-npx ts-node -e "
-const { PrismaClient } = require('@prisma/client');
-const bcrypt = require('bcrypt');
-
-const prisma = new PrismaClient();
-
-async function main() {
-  const hash = await bcrypt.hash('password123', 10);
-  const user = await prisma.user.create({
-    data: {
-      email: 'test@example.com',
-      username: 'testuser',
-      passwordHash: hash,
-      emailVerified: true,
-    },
-  });
-  console.log('Created user:', user.email);
-}
-
-main().finally(() => prisma.\$disconnect());
-"
-```
-
-Then login with:
-- Email: `test@example.com`
-- Password: `password123`
+### Option 2: Use OAuth for a local account
+Use the frontend login page and sign in with one of the configured OAuth providers.
 
 ---
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -160,24 +160,7 @@ export class AppModule {}
 
 ### Input Validation
 
-```typescript
-import { IsEmail, IsString, MinLength, Matches } from 'class-validator';
-
-export class RegisterDto {
-  @IsEmail()
-  email: string;
-
-  @IsString()
-  @MinLength(3)
-  @Matches(/^[a-zA-Z0-9_-]+$/)
-  username: string;
-
-  @IsString()
-  @MinLength(8)
-  @Matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]/)
-  password: string;
-}
-```
+OAuth callback payloads and any authenticated mutations should still be validated with DTOs and provider-specific checks.
 
 ### CORS Configuration
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -31,8 +31,8 @@ npm run start:dev
 ```
 
 **Endpoints:**
-- `POST /auth/login` - User login
-- `POST /auth/register` - User registration
+- `GET /auth/lichess/login` - Start Lichess OAuth
+- `GET /auth/google/login` - Start Google OAuth
 - `GET /games` - List user games
 - `POST /sync/trigger` - Trigger game sync
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -196,7 +196,7 @@ import { cn } from '../lib/utils';
 
 ### Flow
 
-1. User logs in with email/password
+1. User logs in with OAuth (Lichess or Google)
 2. JWT tokens stored in `localStorage`
 3. `AuthContext` provides auth state app-wide
 4. API client interceptor adds `Authorization` header

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,13 +1,11 @@
 import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
 import { authService } from '../services/authService';
-import type { User, LoginRequest, RegisterRequest } from '../types/api';
+import type { User } from '../types/api';
 
 interface AuthContextType {
     user: User | null;
     isAuthenticated: boolean;
     isLoading: boolean;
-    login: (credentials: LoginRequest) => Promise<void>;
-    register: (data: RegisterRequest) => Promise<{ message: string }>;
     logout: () => void;
     refreshUser: () => Promise<void>;
 }
@@ -38,21 +36,6 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         initAuth();
     }, []);
 
-    const login = useCallback(async (credentials: LoginRequest) => {
-        setIsLoading(true);
-        try {
-            const response = await authService.login(credentials);
-            setUser(response.user);
-        } finally {
-            setIsLoading(false);
-        }
-    }, []);
-
-    const register = useCallback(async (data: RegisterRequest) => {
-        const response = await authService.register(data);
-        return { message: response.message };
-    }, []);
-
     const logout = useCallback(() => {
         authService.logout();
         setUser(null);
@@ -72,8 +55,6 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         user,
         isAuthenticated: !!user,
         isLoading,
-        login,
-        register,
         logout,
         refreshUser,
     };

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -1,32 +1,7 @@
 import { apiClient } from './apiClient';
-import type { AuthResponse, LoginRequest, RegisterRequest, User } from '../types/api';
-
-interface RegisterResponse {
-    message: string;
-    user: {
-        id: string;
-        email: string;
-        username: string;
-        isVerified: boolean;
-    };
-}
+import type { User } from '../types/api';
 
 export const authService = {
-    async login(credentials: LoginRequest): Promise<AuthResponse> {
-        const response = await apiClient.post<AuthResponse>('/auth/login', credentials);
-
-        // Store tokens
-        localStorage.setItem('accessToken', response.tokens.accessToken);
-        localStorage.setItem('refreshToken', response.tokens.refreshToken);
-
-        return response;
-    },
-
-    async register(data: RegisterRequest): Promise<RegisterResponse> {
-        const response = await apiClient.post<RegisterResponse>('/auth/register', data);
-        return response;
-    },
-
     async verifyEmail(token: string): Promise<{ message: string; verified: boolean }> {
         return apiClient.get<{ message: string; verified: boolean }>(`/auth/verify-email?token=${token}`);
     },

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -13,26 +13,6 @@ export interface User {
     createdAt: string;
 }
 
-export interface LoginRequest {
-    email: string;
-    password: string;
-}
-
-export interface RegisterRequest {
-    email: string;
-    username: string;
-    password: string;
-}
-
-export interface AuthResponse {
-    user: User;
-    tokens: {
-        accessToken: string;
-        refreshToken: string;
-        expiresIn: number;
-    };
-}
-
 // Game Types
 export interface Game {
     id: string;


### PR DESCRIPTION
 ## Summary
  Removed the email/password authentication flow and aligns the app with the current OAuth-only direction.

  ## Changes
  - removed backend `POST /auth/login`
  - removed backend `POST /auth/register`
  - removed the related DTOs and auth service methods for email/password auth
  - removed unused frontend auth types/context/service methods related to to email/password login/register
  - updated docs and quickstart section that still described password-based auth
  - updated seed output so it no longer shows demo password credentials